### PR TITLE
Fixes to make it build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Instruction for building crystal project and rust library
 
 ```sh
-$ (cd verkle_crypto; cargo build) 
+$ (cd verkle_crypto; cargo build --release) 
 $ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--link-flags=-Wl,-ld_classic" GC_DONT_GC=1 crystal build src/main.cr -o pampero
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
+## Requiriements
+
+A recent version of [Crystal](https://crystal-lang.org/install) and [Rust](https://www.rust-lang.org/tools/install).
+
 ## Building
 
-Instruction for building crystal project and rust library
+Instruction for building crystal project and the `verke_crypto` rust library it depends on.
 
 ```sh
 $ (cd verkle_crypto; cargo build --release) 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A recent version of [Crystal](https://crystal-lang.org/install) and [Rust](https
 Instruction for building crystal project and the `verke_crypto` rust library it depends on.
 
 ```sh
-$ (cd verkle_crypto; cargo build --release) 
+$ (cd verkle_crypto; cargo build --release)
+$ shards install
 $ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH crystal build src/main.cr -o pampero
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Instruction for building crystal project and the `verke_crypto` rust library it 
 
 ```sh
 $ (cd verkle_crypto; cargo build --release) 
-$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--link-flags=-Wl,-ld_classic" GC_DONT_GC=1 crystal build src/main.cr -o pampero
+$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH crystal build src/main.cr -o pampero
 ```
 
 ## Show block details
@@ -16,13 +16,13 @@ $ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--l
 Block at latest slot
 
 ```sh
-$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--link-flags=-Wl,-ld_classic" GC_DONT_GC=1 crystal run src/dump_block.cr
+$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH crystal run src/dump_block.cr
 ```
 
 Block at slot 831627
 
 ```sh
-$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--link-flags=-Wl,-ld_classic" GC_DONT_GC=1 crystal run src/dump_block.cr  -- 831627
+$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH crystal run src/dump_block.cr  -- 831627
 ```
 
 ## Unit tests
@@ -30,6 +30,6 @@ $ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--l
 To run all the tests
 
 ```sh
-$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH CRYSTAL_OPTS="--link-flags=-Wl,-ld_classic" GC_DONT_GC=1 crystal spec
+$ LIBRARY_PATH=$(PWD)/verkle_crypto/target/debug:$LIBRARY_PATH crystal spec
 ```
 

--- a/src/config.cr
+++ b/src/config.cr
@@ -1,10 +1,9 @@
 module Pampero
-
   class Config
     getter beacon_node : String
 
     def initialize
-      @beacon_node = ENV["BEACON_NODE"] || ""
+      @beacon_node = ENV["BEACON_NODE"]? || ""
     end
   end
 end

--- a/src/models/account.cr
+++ b/src/models/account.cr
@@ -1,5 +1,6 @@
 require "../common/types"
 require "../common/constants"
+require "json"
 
 module Pampero
   struct Account


### PR DESCRIPTION
The description to make it build wasn't entirely correct. #2 was found while trying to run it, but it's kept unsolved.

In essence:
 * There was [a missing step](aac75f7206a35b00075e6a3e2b0944f9c416e4f5).
 * Some options are not necessary, in particular in the last version of Crystal or non-mac users [ref](5a85ee99a1dcb9f81c893537b2f1a0e5401f0e11).

Also, there are other minor tweaks, see the log.